### PR TITLE
Fix spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 Napi-js
 =====
 
-Node.js library for downloading movie subtitles using [NapiProjekt](http://www.napiprojekt.pl/) API.
+A Node.js library for downloading movie subtitles using the [NapiProjekt](http://www.napiprojekt.pl/) API.
 
 ## Usage
 ```bash
-> npm install napi-js
+npm install napi-js
 ```
 
-Next just do something like that:
+Next just do something like this:
 
 ```javascript
 var napijs = require('../napi-js');
@@ -24,21 +24,17 @@ napijs.downloadSubtitles('MY_MOVIE.mkv', napijs.LANGUAGE.POLISH).then(function (
 );
 ```
 
-Napi-js use [promises](https://github.com/kriskowal/q).
+Napi-js uses [promises](https://github.com/kriskowal/q).
 
-Subtitles are save under this same name and directory as movie file but with _.txt_ extension.
+Subtitles are saved under the same directory and name as the movie file but with a _.txt_ extension.
 
-## Using in command line
+## Command line usage
 
-It's also possible to use `napijs` as a command line tool. To do so install it as a global package:
+It's also possible to use `napijs` as a command line tool. To do so, install it as a global package:
 
 ```bash
-> npm i napijs -g
-```
-
-and then:
-```bash
-> napijs path/to/video/file
+npm i napijs -g
+napijs path/to/video/file
 ```
 
 License

--- a/napi-js.js
+++ b/napi-js.js
@@ -17,18 +17,18 @@ function downloadSubtitles(fileName, language) {
     var deferred = Q.defer();
 
     if (!fileName) {
-        deferred.reject('File name is missing');
+        deferred.reject('Missing file name.');
         return deferred.promise;
     }
     if (!language) {
-        deferred.reject('Language is missing');
+        deferred.reject('Missing language.');
         return deferred.promise;
     }
 
     fs.stat(fileName, function (err) {
         if (err) {
             if (err.code === 'ENOENT') {
-                deferred.reject('Such a file does not exist.');
+                deferred.reject('File does not exist.');
             } else {
                 deferred.reject(err);
             }
@@ -36,7 +36,7 @@ function downloadSubtitles(fileName, language) {
             deferred.notify('Generating hash for file ' + fileName);
             md5pf(fileName, 0, 10485760, function (err, hash) {
                 if (err) {
-                    deferred.reject('Something went wrong during md5 hash calculation of partial file.');
+                    deferred.reject('Something went wrong during md5 hash calculation.');
                 } else {
                     deferred.notify('Hash: ' + hash);
 
@@ -61,7 +61,7 @@ function downloadSubtitles(fileName, language) {
                     };
                     var req = http.request(post_options, function (res) {
                         res.setEncoding('utf-8');
-                        deferred.notify('Response from server received');
+                        deferred.notify('Response from server received.');
                         deferred.notify('Downloading...');
 
                         var responseString = '';
@@ -85,7 +85,7 @@ function downloadSubtitles(fileName, language) {
                                                 path.dirname(fileName),
                                                 path.basename(fileName, path.extname(fileName)) + '.txt'
                                             );
-                                            deferred.notify('Saving file ' + subsFileName);
+                                            deferred.notify('Saving file: ' + subsFileName);
                                             var file = fs.createWriteStream(subsFileName);
                                             var subs = result.result.subtitles[0];
 
@@ -95,20 +95,20 @@ function downloadSubtitles(fileName, language) {
                                                 deferred.reject(err);
                                             });
                                             file.on('finish', function () {
-                                                deferred.notify('File saved successfully');
+                                                deferred.notify('File saved successfully.');
                                                 file.close(function () {
                                                     deferred.resolve(subsFileName);
                                                 });
                                             });
                                             file.end();
                                         } else {
-                                            deferred.reject('Wrong number of subtitles');
+                                            deferred.reject('Wrong number of subtitles.');
                                         }
                                     } else {
-                                        deferred.reject('No subtitles in result');
+                                        deferred.reject('No subtitles in reponse.');
                                     }
                                 } else {
-                                    deferred.reject('No result');
+                                    deferred.reject('No response.');
                                 }
                             });
                         });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "napi-js",
   "version": "1.1.1",
   "private": false,
-  "description": "Library for downloading movie subtitles using NapiProjekt API.",
+  "description": "A library for downloading movie subtitles using the NapiProjekt API.",
   "homepage": "https://github.com/kozervar/napi-js",
   "author": "Marcin Kozaczyk <kozervar@gmail.com> (http://github.com/kozervar)",
   "keywords": [


### PR DESCRIPTION
- fixed minor English spelling mistakes
- improved phrasing
- removed `>` from bash code blocks (everyone already knows it should be ran in a command line)
- made punctuation consistent in log messages
