### PR TITLE
Fix package.json license and indentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "A library for downloading movie subtitles using the NapiProjekt API.",
   "homepage": "https://github.com/kozervar/napi-js",
   "author": "Marcin Kozaczyk <kozervar@gmail.com> (http://github.com/kozervar)",
+  "license": "MIT",
   "keywords": [
     "napiprojekt",
     "napiproject",
@@ -22,10 +23,7 @@
     "mail": "kozervar@gmail.com",
     "url": "http://github.com/kozervar/napi-js/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "http://github.com/kozervar/napi-js/raw/master/LICENSE"
-  },
+
   "bin": {
     "napijs": "./bin/cmd.js"
   },
@@ -33,7 +31,7 @@
   "files": [
     "LICENSE",
     "napi-js.js",
-	"bin/*"
+    "bin/*"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Apparently the license syntax in package.json changed to respect SPDX strings and now npm nags about an invalid license definition.

https://docs.npmjs.com/files/package.json

PS
Working on a nicer command line interface accepting globs. It requires `glob` (obviously) and `node-ffprobe` for video file discovery. Is that a problem? I'm not sure how minimalist you want to keep this project.
